### PR TITLE
feat: add secondary RGB zone support for OXP devices

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ class Plugin:
         brightness: int | None = None,
         speed: str | None = None,
         brightness_level: str | None = None,
+        zone_colors: dict | None = None,
     ):
         try:
             from utils import Color, RGBMode
@@ -55,13 +56,26 @@ class Plugin:
             if r2 is not None and g2 is not None and b2 is not None:
                 color2 = Color(r2, g2, b2)
 
+            # Convert zone_colors dict to Color objects
+            # 将 zone_colors 字典转换为 Color 对象
+            zone_colors_converted = None
+            if zone_colors:
+                zone_colors_converted = {}
+                for zone_id, color_dict in zone_colors.items():
+                    if color_dict and 'R' in color_dict and 'G' in color_dict and 'B' in color_dict:
+                        zone_colors_converted[zone_id] = Color(
+                            color_dict['R'],
+                            color_dict['G'],
+                            color_dict['B']
+                        )
+
             rgb_mode = (
                 next((m for m in RGBMode if m.value == mode.lower()), None)
                 if mode
                 else None
             )
             self.ledControl.set_color(
-                rgb_mode, color, color2, init=init, brightness=brightness, speed=speed, brightness_level=brightness_level
+                rgb_mode, color, color2, zone_colors=zone_colors_converted, init=init, brightness=brightness, speed=speed, brightness_level=brightness_level
             )
             return True
         except Exception as e:
@@ -166,6 +180,7 @@ class Plugin:
                     "speed": cap.speed,
                     "brightness": cap.brightness,
                     "brightness_level": cap.brightness_level,
+                    "zones": cap.zones,  # Add zones field
                 }
                 for mode, cap in capabilities.items()
             }

--- a/py_modules/devices/led_device.py
+++ b/py_modules/devices/led_device.py
@@ -42,6 +42,7 @@ class LEDDevice(ABC):
         mode: RGBMode | None = None,
         color: Color | None = None,
         color2: Color | None = None,
+        zone_colors: dict[str, Color] | None = None,
         init: bool = False,
         brightness: int | None = None,
         speed: str | None = None,
@@ -55,6 +56,7 @@ class LEDDevice(ABC):
             mode: RGB mode to set
             color: Primary color
             color2: Secondary color (for dual-color modes)
+            zone_colors: Zone color mapping, e.g., {'secondary': Color(r, g, b)}
             init: Whether this is an initialization call
             brightness: Software brightness (0-100, for HSV-based modes)
             speed: Animation speed ("low", "medium", "high")
@@ -90,6 +92,32 @@ class LEDDevice(ABC):
     @abstractmethod
     def resume(self) -> None:
         pass
+    
+    def get_device_capabilities(self) -> dict:
+        """
+        Get device hardware capabilities.
+        获取设备硬件能力。
+        
+        Returns:
+            dict: Device capabilities
+            {
+                "zones": [
+                    {"id": "primary", "name_key": "ZONE_PRIMARY_NAME"},
+                ],
+                "power_led": False,
+                "suspend_mode": True,
+            }
+        """
+        return {
+            'zones': [
+                {
+                    'id': 'primary',
+                    'name_key': 'ZONE_PRIMARY_NAME',
+                }
+            ],
+            'power_led': False,
+            'suspend_mode': True,
+        }
 
 
 class BaseLEDDevice(LEDDevice):
@@ -141,6 +169,7 @@ class BaseLEDDevice(LEDDevice):
         mode: RGBMode | None = None,
         color: Color | None = None,
         color2: Color | None = None,
+        zone_colors: dict[str, Color] | None = None,
         init: bool = False,
         speed: str | None = None,
         brightness_level: str | None = None,
@@ -154,6 +183,7 @@ class BaseLEDDevice(LEDDevice):
             mode: RGB mode to set
             color: Primary color
             color2: Secondary color (for dual-color modes)
+            zone_colors: Zone color mapping, e.g., {'secondary': Color(r, g, b)}
             init: Whether this is an initialization call
             speed: Animation speed ("low", "medium", "high")
             brightness_level: Hardware brightness level ("low", "medium", "high")
@@ -166,6 +196,7 @@ class BaseLEDDevice(LEDDevice):
         mode: RGBMode | None = None,
         color: Color | None = None,
         color2: Color | None = None,
+        zone_colors: dict[str, Color] | None = None,
         init: bool = False,
         brightness: int | None = None,
         speed: str | None = None,
@@ -180,6 +211,7 @@ class BaseLEDDevice(LEDDevice):
             mode: RGB mode to set
             color: Primary color
             color2: Secondary color (for dual-color modes)
+            zone_colors: Zone color mapping, e.g., {'secondary': Color(r, g, b)}
             init: Whether this is an initialization call
             brightness: Software brightness (0-100, for HSV-based modes)
             speed: Animation speed ("low", "medium", "high")
@@ -197,7 +229,7 @@ class BaseLEDDevice(LEDDevice):
             try:
                 logger.info(f"use hardware control: mode={mode}")
                 self.stop_effects()
-                self._set_hardware_color(mode, color, color2, init, speed=speed, brightness_level=brightness_level, **kwargs)
+                self._set_hardware_color(mode, color, color2, zone_colors, init, speed=speed, brightness_level=brightness_level, **kwargs)
                 return
             except Exception as e:
                 logger.error(e, exc_info=True)

--- a/py_modules/devices/onexplayer_configs.py
+++ b/py_modules/devices/onexplayer_configs.py
@@ -107,6 +107,7 @@ ONEXPLAYER_CONFIGS = {
         name="ONEXPLAYER X1 Air",
         protocol=OXPProtocol.HID_V1,
         rgb=True,
+        rgb_secondary=True,
     ),
     
     # ========== X1 Series (Serial) ==========

--- a/py_modules/huesync.py
+++ b/py_modules/huesync.py
@@ -96,6 +96,7 @@ class LedControl:
         mode: RGBMode | None = None,
         color: Color | None = None,
         color2: Color | None = None,
+        zone_colors: dict[str, Color] | None = None,
         init: bool = False,
         brightness: int | None = None,
         speed: str | None = None,
@@ -108,6 +109,7 @@ class LedControl:
             mode or RGBMode.Solid,
             color,
             color2,
+            zone_colors=zone_colors,
             init=init,
             brightness=brightness,
             speed=speed,
@@ -176,16 +178,25 @@ class LedControl:
         Returns:
             dict: Device capabilities
             {
+                "zones": [{"id": "primary", "name_key": "ZONE_PRIMARY_NAME"}],
                 "power_led": bool,  # Whether power LED control is supported
+                "suspend_mode": bool,  # Whether suspend mode control is supported
             }
         """
-        return {
-            "power_led": (
+        # Get base capabilities from device
+        # 从设备获取基础能力
+        base_caps = self.device.get_device_capabilities()
+        
+        # Add legacy power_led check for backward compatibility
+        # 为向后兼容性添加传统的power_led检查
+        if "power_led" not in base_caps:
+            base_caps["power_led"] = (
                 hasattr(self.device, 'set_power_light') and 
                 hasattr(self.device, 'get_power_light') and
                 getattr(self.device, '_power_led_available', False)
-            ),
-        }
+            )
+        
+        return base_caps
 
     def set_power_light(self, enabled: bool) -> bool:
         """

--- a/py_modules/led/hhd/oxp_hid_v1.py
+++ b/py_modules/led/hhd/oxp_hid_v1.py
@@ -110,7 +110,7 @@ def gen_brightness(
     }
     bc = brightness_map.get(brightness, 0x04)
     
-    return gen_cmd(0xB8, [0xFD, 0x00, 0x02, int(enabled), 0x05, bc])
+    return gen_cmd(0xB8, [0xFD, side, 0x02, int(enabled), 0x05, bc])
 
 
 def gen_rgb_solid(r: int, g: int, b: int, side: int = 0x00) -> bytes:

--- a/py_modules/utils.py
+++ b/py_modules/utils.py
@@ -62,6 +62,12 @@ class RGBModeCapabilities:
     speed: bool = False  # Whether the mode supports adjusting animation speed
     brightness: bool = False  # Whether the mode supports adjusting HSV brightness (V value)
     brightness_level: bool = False  # Whether the mode supports hardware brightness level (low/medium/high)
+    zones: list[str] | None = None  # Supported zones: ['primary', 'secondary', ...]
+    
+    def __post_init__(self):
+        """Initialize default zones if not provided"""
+        if self.zones is None:
+            self.zones = ['primary']  # Default: only primary zone
 
 
 class Color:

--- a/src/components/RgbSetting.tsx
+++ b/src/components/RgbSetting.tsx
@@ -1,5 +1,6 @@
 import {
   PanelSectionRow,
+  PanelSection,
   DropdownItem,
   gamepadSliderClasses,
   ToggleField,
@@ -171,8 +172,12 @@ export const RGBComponent: FC = () => {
     hue2,
     saturation,
     brightness,
+    secondaryZoneHue,
+    secondaryZoneSaturation,
+    secondaryZoneBrightness,
     setHsv,
     setHue2Value,
+    setSecondaryZoneHsv,
     rgbMode,
     updateRgbMode,
     enableControl,
@@ -187,7 +192,7 @@ export const RGBComponent: FC = () => {
     return Object.entries(Setting.modeCapabilities).map(([mode]) => ({
       label: localizationManager.getString(
         localizeStrEnum[
-          `LED_MODE_${mode.toUpperCase()}` as keyof typeof localizeStrEnum
+        `LED_MODE_${mode.toUpperCase()}` as keyof typeof localizeStrEnum
         ]
       ),
       data: mode,
@@ -204,25 +209,48 @@ export const RGBComponent: FC = () => {
         speed: false,
         brightness: false,
         brightness_level: false,
+        zones: ['primary'],
       }
     );
   }, [rgbMode]);
 
+  // Check if device has secondary zone and current mode supports it
+  // 检查设备是否有副区域且当前模式支持
+  const hasSecondaryZone = useMemo(() => {
+    return (
+      Setting.deviceCapabilities &&
+      Setting.deviceCapabilities.zones &&
+      Setting.deviceCapabilities.zones.length > 1 &&
+      currentModeCapabilities.zones &&
+      currentModeCapabilities.zones.includes('secondary')
+    );
+  }, [currentModeCapabilities]);
+
+  // Get secondary zone name key for i18n
+  // 获取副区域名称key用于i18n
+  const secondaryZoneNameKey = useMemo(() => {
+    if (!Setting.deviceCapabilities?.zones) return null;
+    const secondaryZone = Setting.deviceCapabilities.zones.find(z => z.id === 'secondary');
+    return secondaryZone?.name_key || null;
+  }, []);
+
   return (
     <>
-      <PanelSectionRow>
-        <ToggleField
-          label={localizationManager.getString(
-            localizeStrEnum.ENABLE_LED_CONTROL
-          )}
-          checked={enableControl}
-          onChange={(value) => {
-            updateEnableControl(value);
-          }}
-        />
-      </PanelSectionRow>
-      {enableControl && (
-        <>
+      <PanelSection
+        title={localizationManager.getString(localizeStrEnum.RGB_BASIC_SETTINGS)}
+      >
+        <PanelSectionRow>
+          <ToggleField
+            label={localizationManager.getString(
+              localizeStrEnum.ENABLE_LED_CONTROL
+            )}
+            checked={enableControl}
+            onChange={(value) => {
+              updateEnableControl(value);
+            }}
+          />
+        </PanelSectionRow>
+        {enableControl && (
           <PanelSectionRow>
             <DropdownItem
               label={localizationManager.getString(localizeStrEnum.LED_MODE)}
@@ -239,29 +267,60 @@ export const RGBComponent: FC = () => {
                 }
               }}
             />
-          </PanelSectionRow>
+          </PanelSectionRow>)}
+      </PanelSection>
+      {enableControl && (
+        <>
+          {/* Primary Zone Section | 主区域设置 */}
           {(currentModeCapabilities.color ||
-            currentModeCapabilities.brightness) && (
-            <ColorControls
-              hue={hue}
-              saturation={saturation}
-              brightness={brightness}
-              setHsv={setHsv}
-              supportsColor2={currentModeCapabilities.color2}
-              hue2={hue2}
-              setHue2={setHue2Value}
-              onlyBrightness={currentModeCapabilities.brightness}
-            />
-          )}
-          {currentModeCapabilities.speed && (
-            <PanelSectionRow>
-              <SpeedControl speed={speed} onChange={updateSpeed} />
-            </PanelSectionRow>
-          )}
-          {currentModeCapabilities.brightness_level && (
-            <PanelSectionRow>
-              <BrightnessLevelControl brightnessLevel={brightnessLevel} onChange={updateBrightnessLevel} />
-            </PanelSectionRow>
+            currentModeCapabilities.brightness ||
+            currentModeCapabilities.speed ||
+            currentModeCapabilities.brightness_level) && (
+              <PanelSection
+                title={localizationManager.getString(localizeStrEnum.ZONE_PRIMARY_NAME)}
+              >
+                {(currentModeCapabilities.color ||
+                  currentModeCapabilities.brightness) && (
+                    <ColorControls
+                      hue={hue}
+                      saturation={saturation}
+                      brightness={brightness}
+                      setHsv={setHsv}
+                      supportsColor2={currentModeCapabilities.color2}
+                      hue2={hue2}
+                      setHue2={setHue2Value}
+                      onlyBrightness={currentModeCapabilities.brightness}
+                    />
+                  )}
+                {currentModeCapabilities.speed && (
+                  <PanelSectionRow>
+                    <SpeedControl speed={speed} onChange={updateSpeed} />
+                  </PanelSectionRow>
+                )}
+                {currentModeCapabilities.brightness_level && (
+                  <PanelSectionRow>
+                    <BrightnessLevelControl brightnessLevel={brightnessLevel} onChange={updateBrightnessLevel} />
+                  </PanelSectionRow>
+                )}
+              </PanelSection>
+            )}
+
+          {/* Secondary Zone Section | 副区域设置 */}
+          {hasSecondaryZone && secondaryZoneNameKey && (
+            <PanelSection
+              title={localizationManager.getString(
+                localizeStrEnum[secondaryZoneNameKey as keyof typeof localizeStrEnum]
+              )}
+            >
+              <ColorControls
+                hue={secondaryZoneHue}
+                saturation={secondaryZoneSaturation}
+                brightness={secondaryZoneBrightness}
+                setHsv={setSecondaryZoneHsv}
+                supportsColor2={false}
+                onlyBrightness={false}
+              />
+            </PanelSection>
           )}
         </>
       )}

--- a/src/hooks/settings.ts
+++ b/src/hooks/settings.ts
@@ -1,4 +1,4 @@
-import { Backend, hsvToRgb, Logger, RGBMode, RGBModeCapabilities, RunningApps, ACStateManager, EACState, DEFAULT_APP } from "../util";
+import { Backend, hsvToRgb, Logger, RGBMode, RGBModeCapabilities, RunningApps, ACStateManager, EACState, DEFAULT_APP, DeviceCapabilities } from "../util";
 
 export class RgbSetting {
   public enableControl = false;
@@ -9,6 +9,9 @@ export class RgbSetting {
   public hue2 = 0;
   public saturation2 = 100;
   public brightness2 = 100;
+  public secondaryZoneHue = 0;
+  public secondaryZoneSaturation = 100;
+  public secondaryZoneBrightness = 100;
   public speed = "low";
   public brightnessLevel = "high";
 
@@ -21,6 +24,9 @@ export class RgbSetting {
     this.hue2 = source.hue2;
     this.saturation2 = source.saturation2;
     this.brightness2 = source.brightness2;
+    this.secondaryZoneHue = source.secondaryZoneHue;
+    this.secondaryZoneSaturation = source.secondaryZoneSaturation;
+    this.secondaryZoneBrightness = source.secondaryZoneBrightness;
     this.speed = source.speed;
     this.brightnessLevel = source.brightnessLevel;
   }
@@ -53,6 +59,21 @@ export class RgbSetting {
 
   get blue2(): number {
     const [, , b] = hsvToRgb(this.hue2, this.saturation2, this.brightness2);
+    return b;
+  }
+
+  get secondaryZoneRed(): number {
+    const [r] = hsvToRgb(this.secondaryZoneHue, this.secondaryZoneSaturation, this.secondaryZoneBrightness);
+    return r;
+  }
+
+  get secondaryZoneGreen(): number {
+    const [, g] = hsvToRgb(this.secondaryZoneHue, this.secondaryZoneSaturation, this.secondaryZoneBrightness);
+    return g;
+  }
+
+  get secondaryZoneBlue(): number {
+    const [, , b] = hsvToRgb(this.secondaryZoneHue, this.secondaryZoneSaturation, this.secondaryZoneBrightness);
     return b;
   }
 }
@@ -188,6 +209,7 @@ export class Setting {
   // Static members | 静态成员
   public static isSupportSuspendMode: boolean = false;
   public static modeCapabilities: Record<string, RGBModeCapabilities> = {};
+  public static deviceCapabilities: DeviceCapabilities | null = null;
 
   // Event system for configuration changes | 配置变更事件系统
   private static settingChangeEvent = new EventTarget();
@@ -317,13 +339,15 @@ export class Setting {
       this._settingsData.perApp[DEFAULT_APP] = new AppRgbData();
     }
 
-    const [isSupportSuspendMode, modeCapabilities] = await Promise.all([
+    const [isSupportSuspendMode, modeCapabilities, deviceCapabilities] = await Promise.all([
       Backend.isSupportSuspendMode(),
       Backend.getModeCapabilities(),
+      Backend.getDeviceCapabilities(),
     ]);
 
     this.isSupportSuspendMode = isSupportSuspendMode;
     this.modeCapabilities = modeCapabilities;
+    this.deviceCapabilities = deviceCapabilities;
   }
 
   public static async loadSettingsData() {
@@ -435,6 +459,24 @@ export class Setting {
 
   @Setting.readonlyProperty<number>("blue2")
   public static blue2: number;
+
+  @Setting.settingProperty<number>("secondaryZoneHue")
+  public static secondaryZoneHue: number;
+
+  @Setting.settingProperty<number>("secondaryZoneSaturation")
+  public static secondaryZoneSaturation: number;
+
+  @Setting.settingProperty<number>("secondaryZoneBrightness")
+  public static secondaryZoneBrightness: number;
+
+  @Setting.readonlyProperty<number>("secondaryZoneRed")
+  public static secondaryZoneRed: number;
+
+  @Setting.readonlyProperty<number>("secondaryZoneGreen")
+  public static secondaryZoneGreen: number;
+
+  @Setting.readonlyProperty<number>("secondaryZoneBlue")
+  public static secondaryZoneBlue: number;
 
   @Setting.settingProperty<string>("speed")
   public static speed: string;

--- a/src/hooks/useRgb.ts
+++ b/src/hooks/useRgb.ts
@@ -8,6 +8,10 @@ export const useRgb = () => {
   const [saturation, setSaturation] = useState<number>(Setting.saturation);
   const [brightness, setBrightness] = useState<number>(Setting.brightness);
 
+  const [secondaryZoneHue, setSecondaryZoneHue] = useState<number>(Setting.secondaryZoneHue);
+  const [secondaryZoneSaturation, setSecondaryZoneSaturation] = useState<number>(Setting.secondaryZoneSaturation);
+  const [secondaryZoneBrightness, setSecondaryZoneBrightness] = useState<number>(Setting.secondaryZoneBrightness);
+
   const [rgbMode, setRgbMode] = useState<RGBMode>(Setting.mode);
 
   const [enableControl, setEnableControl] = useState<boolean>(
@@ -24,6 +28,9 @@ export const useRgb = () => {
       setHue2(Setting.hue2);
       setSaturation(Setting.saturation);
       setBrightness(Setting.brightness);
+      setSecondaryZoneHue(Setting.secondaryZoneHue);
+      setSecondaryZoneSaturation(Setting.secondaryZoneSaturation);
+      setSecondaryZoneBrightness(Setting.secondaryZoneBrightness);
       setRgbMode(Setting.mode);
       setEnableControl(Setting.enableControl);
       setSpeed(Setting.speed);
@@ -92,13 +99,35 @@ export const useRgb = () => {
     await Backend.applySettings();
   };
 
+  const setSecondaryZoneHsv = async (
+    h: number,
+    s: number,
+    v: number,
+    apply: boolean = true
+  ) => {
+    setSecondaryZoneHue(h);
+    setSecondaryZoneSaturation(s);
+    setSecondaryZoneBrightness(v);
+    Setting.secondaryZoneHue = h;
+    Setting.secondaryZoneSaturation = s;
+    Setting.secondaryZoneBrightness = v;
+
+    if (apply) {
+      await Backend.applySettings();
+    }
+  };
+
   return {
     hue,
     hue2,
     saturation,
     brightness,
+    secondaryZoneHue,
+    secondaryZoneSaturation,
+    secondaryZoneBrightness,
     setHsv,
     setHue2Value,
+    setSecondaryZoneHsv,
     rgbMode,
     updateRgbMode,
     enableControl,

--- a/src/i18n/bulgarian.json
+++ b/src/i18n/bulgarian.json
@@ -69,5 +69,10 @@
     "PROFILE": " Профил",
     "AC_MODE": "Режим на захранване",
     "BAT_MODE": "Режим на батерия",
-    "UNKNOWN": "Неизвестно"
+    "UNKNOWN": "Неизвестно",
+    "ZONE_PRIMARY_NAME": "Джойстици",
+    "ZONE_SECONDARY_CENTER_NAME": "Централна зона",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "Преден панел",
+    "ZONE_SECONDARY_GENERIC_NAME": "Вторична зона",
+    "RGB_BASIC_SETTINGS": "Контрол на осветлението"
 }

--- a/src/i18n/english.json
+++ b/src/i18n/english.json
@@ -69,5 +69,10 @@
     "PROFILE": " Profile",
     "AC_MODE": "AC Mode",
     "BAT_MODE": "Battery Mode",
-    "UNKNOWN": "Unknown"
+    "UNKNOWN": "Unknown",
+    "ZONE_PRIMARY_NAME": "Joysticks",
+    "ZONE_SECONDARY_CENTER_NAME": "Center Zone",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "Front Panel",
+    "ZONE_SECONDARY_GENERIC_NAME": "Secondary Zone",
+    "RGB_BASIC_SETTINGS": "Light Control"
 }

--- a/src/i18n/french.json
+++ b/src/i18n/french.json
@@ -69,5 +69,10 @@
     "PROFILE": " Profil",
     "AC_MODE": "Mode secteur",
     "BAT_MODE": "Mode batterie",
-    "UNKNOWN": "Inconnu"
+    "UNKNOWN": "Inconnu",
+    "ZONE_PRIMARY_NAME": "Joysticks",
+    "ZONE_SECONDARY_CENTER_NAME": "Zone centrale",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "Panneau avant",
+    "ZONE_SECONDARY_GENERIC_NAME": "Zone secondaire",
+    "RGB_BASIC_SETTINGS": "Contrôle d'éclairage"
 }

--- a/src/i18n/german.json
+++ b/src/i18n/german.json
@@ -69,5 +69,10 @@
     "PROFILE": " Profil",
     "AC_MODE": "Netzbetrieb",
     "BAT_MODE": "Akkubetrieb",
-    "UNKNOWN": "Unbekannt"
+    "UNKNOWN": "Unbekannt",
+    "ZONE_PRIMARY_NAME": "Joysticks",
+    "ZONE_SECONDARY_CENTER_NAME": "Zentrale Zone",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "Frontpanel",
+    "ZONE_SECONDARY_GENERIC_NAME": "Sekundäre Zone",
+    "RGB_BASIC_SETTINGS": "Lichtsteuerung"
 }

--- a/src/i18n/italian.json
+++ b/src/i18n/italian.json
@@ -69,5 +69,10 @@
     "PROFILE": " Profilo",
     "AC_MODE": "Modalità AC",
     "BAT_MODE": "Modalità batteria",
-    "UNKNOWN": "Sconosciuto"
+    "UNKNOWN": "Sconosciuto",
+    "ZONE_PRIMARY_NAME": "Joysticks",
+    "ZONE_SECONDARY_CENTER_NAME": "Zona centrale",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "Pannello frontale",
+    "ZONE_SECONDARY_GENERIC_NAME": "Zona secondaria",
+    "RGB_BASIC_SETTINGS": "Controllo luci"
 }

--- a/src/i18n/japanese.json
+++ b/src/i18n/japanese.json
@@ -69,5 +69,10 @@
     "PROFILE": "設定",
     "AC_MODE": "AC電源モード",
     "BAT_MODE": "バッテリーモード",
-    "UNKNOWN": "不明"
+    "UNKNOWN": "不明",
+    "ZONE_PRIMARY_NAME": "ジョイスティック",
+    "ZONE_SECONDARY_CENTER_NAME": "センターゾーン",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "フロントパネル",
+    "ZONE_SECONDARY_GENERIC_NAME": "セカンダリゾーン",
+    "RGB_BASIC_SETTINGS": "ライト制御"
 }

--- a/src/i18n/koreana.json
+++ b/src/i18n/koreana.json
@@ -69,5 +69,10 @@
     "PROFILE": " 프로필",
     "AC_MODE": "AC 전원 모드",
     "BAT_MODE": "배터리 모드",
-    "UNKNOWN": "알 수 없음"
+    "UNKNOWN": "알 수 없음",
+    "ZONE_PRIMARY_NAME": "조이스틱",
+    "ZONE_SECONDARY_CENTER_NAME": "센터 영역",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "전면 패널",
+    "ZONE_SECONDARY_GENERIC_NAME": "보조 영역",
+    "RGB_BASIC_SETTINGS": "조명 제어"
 }

--- a/src/i18n/schinese.json
+++ b/src/i18n/schinese.json
@@ -69,5 +69,10 @@
     "PROFILE": "配置",
     "AC_MODE": "插电模式",
     "BAT_MODE": "电池模式",
-    "UNKNOWN": "未知"
+    "UNKNOWN": "未知",
+    "ZONE_PRIMARY_NAME": "摇杆",
+    "ZONE_SECONDARY_CENTER_NAME": "中央区域",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "前面板",
+    "ZONE_SECONDARY_GENERIC_NAME": "副区域",
+    "RGB_BASIC_SETTINGS": "灯光控制"
 }

--- a/src/i18n/tchinese.json
+++ b/src/i18n/tchinese.json
@@ -69,5 +69,10 @@
     "PROFILE": "配置",
     "AC_MODE": "插電模式",
     "BAT_MODE": "電池模式",
-    "UNKNOWN": "未知"
+    "UNKNOWN": "未知",
+    "ZONE_PRIMARY_NAME": "搖桿",
+    "ZONE_SECONDARY_CENTER_NAME": "中央區域",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "前面板",
+    "ZONE_SECONDARY_GENERIC_NAME": "副區域",
+    "RGB_BASIC_SETTINGS": "燈光控制"
 }

--- a/src/i18n/thai.json
+++ b/src/i18n/thai.json
@@ -69,5 +69,10 @@
     "PROFILE": "โปรไฟล์",
     "AC_MODE": "โหมดเสียบปลั๊ก",
     "BAT_MODE": "โหมดแบตเตอรี่",
-    "UNKNOWN": "ไม่ทราบ"
+    "UNKNOWN": "ไม่ทราบ",
+    "ZONE_PRIMARY_NAME": "จอยสติ๊ก",
+    "ZONE_SECONDARY_CENTER_NAME": "โซนกลาง",
+    "ZONE_SECONDARY_FRONT_PANEL_NAME": "แผงหน้า",
+    "ZONE_SECONDARY_GENERIC_NAME": "โซนรอง",
+    "RGB_BASIC_SETTINGS": "การควบคุมไฟ"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,10 +22,10 @@ const Content: FC = () => {
       >
         <PerAppControl />
         <AcStateControl />
-        <RGBComponent />
         <SuspendModeComponent />
         <PowerLedControl />
       </PanelSection>
+      <RGBComponent />
       <MoreComponent />
     </div>
   );
@@ -36,25 +36,25 @@ export default definePlugin(() => {
     await localizationManager.init();
     await Backend.init();
     await Setting.init();
-    
+
     // Register app and AC state monitoring
     RunningApps.register();
     ACStateManager.register();
-    
+
     // Listen for app changes
     RunningApps.listenActiveChange((newAppId, oldAppId) => {
       console.log(`[HueSync] App changed: ${oldAppId} -> ${newAppId}`);
       Backend.applySettings({ isInit: false });
       Setting.notifyChange();
     });
-    
+
     // Listen for AC state changes
     ACStateManager.onACStateChange(() => {
       console.log(`[HueSync] AC state changed`);
       Backend.applySettings({ isInit: false });
       Setting.notifyChange();
     });
-    
+
     Backend.applySettings({ isInit: true });
   }
 
@@ -63,7 +63,7 @@ export default definePlugin(() => {
   SteamUtils.RegisterForOnResumeFromSuspend(async () => {
     setTimeout(async () => {
       Backend.applySettings({ isInit: true });
-      
+
       // Power LED resume handling | 电源灯唤醒恢复
       if (Setting.powerLedSuspendOff) {
         const savedState = sessionStorage.getItem('powerLedStateBeforeSuspend');
@@ -73,14 +73,14 @@ export default definePlugin(() => {
           console.log("Power LED restored after resume");
         }
       }
-      
+
       console.log("Resume from suspend");
     }, 5000);
   });
 
   SteamUtils.RegisterForOnSuspendRequest(async () => {
     Backend.throwSuspendEvt();
-    
+
     // Power LED suspend handling | 电源灯睡眠处理
     if (Setting.powerLedSuspendOff) {
       const currentState = await Backend.getPowerLight();
@@ -91,7 +91,7 @@ export default definePlugin(() => {
         console.log("Power LED turned off for suspend");
       }
     }
-    
+
     console.log("Entering suspend mode");
   });
   return {

--- a/src/util/rgb.ts
+++ b/src/util/rgb.ts
@@ -5,6 +5,7 @@ export interface RGBModeCapabilities {
   speed: boolean;
   brightness: boolean;
   brightness_level: boolean;
+  zones: string[];
 }
 
 export function hslToRgb(


### PR DESCRIPTION
- Fix gen_brightness bug in oxp_hid_v1.py
- Add secondary zone color control for devices with multiple LED zones
- Implement zone capability reporting and dynamic UI rendering
- Add i18n translations for zone names in all languages