### PR TITLE
fix: missing settings parameter

### DIFF
--- a/py_modules/devices/asus_ally.py
+++ b/py_modules/devices/asus_ally.py
@@ -299,7 +299,7 @@ class AllyLEDDevice(SysfsLEDMixin, AsusLEDDevice):
                 **kwargs
             )
 
-    def suspend(self) -> None:
+    def suspend(self, settings: dict = None) -> None:
         """
         Handle suspend event (before sleep).
         处理挂起事件（睡眠前）。
@@ -308,7 +308,7 @@ class AllyLEDDevice(SysfsLEDMixin, AsusLEDDevice):
         # 当前挂起时无需特殊处理
         pass
 
-    def resume(self) -> None:
+    def resume(self, settings: dict = None) -> None:
         """
         Handle resume event (after wakeup).
         处理恢复事件（唤醒后）。

--- a/py_modules/devices/ayaneo.py
+++ b/py_modules/devices/ayaneo.py
@@ -158,10 +158,10 @@ class AyaNeoLEDDevice(SysfsLEDMixin, BaseLEDDevice):
         logger.debug(f"AyaNeoLEDDevice.set_suspend_mode('{mode}')")
         self.aya_led_device_ec.set_suspend_mode(mode)
 
-    def suspend(self) -> None:
+    def suspend(self, settings: dict = None) -> None:
         self.aya_led_device_ec.suspend()
 
-    def resume(self) -> None:
+    def resume(self, settings: dict = None) -> None:
         self.aya_led_device_ec.resume()
 
     def get_mode_capabilities(self) -> dict[RGBMode, RGBModeCapabilities]:


### PR DESCRIPTION
I've been seeing the following errors in the device's logs:

```log
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]: Failed to handle suspend: AllyLEDDevice.suspend() takes 1 positional argument but 2 were given
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]: Traceback (most recent call last):
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]:   File "/home/deck/homebrew/plugins/HueSync/main.py", line 149, in suspend
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]:     self.ledControl.suspend(suspend_settings)
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]:   File "/home/deck/homebrew/plugins/HueSync/py_modules/huesync.py", line 261, in suspend
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]:     self.device.suspend(settings)
Jun 08 12:35:22 PlayStationMini PluginLoader[2276]: TypeError: AllyLEDDevice.suspend() takes 1 positional argument but 2 were given
Jun 08 12:35:22 PlayStationMini huesync[15478]: [main.py:151:suspend] ERROR: Failed to handle suspend: AllyLEDDevice.suspend() takes 1 positional argument but 2 were given
Jun 08 12:35:22 PlayStationMini huesync[15478]: Traceback (most recent call last):
Jun 08 12:35:22 PlayStationMini huesync[15478]:   File "/home/deck/homebrew/plugins/HueSync/main.py", line 149, in suspend
Jun 08 12:35:22 PlayStationMini huesync[15478]:     self.ledControl.suspend(suspend_settings)
Jun 08 12:35:22 PlayStationMini huesync[15478]:   File "/home/deck/homebrew/plugins/HueSync/py_modules/huesync.py", line 261, in suspend
Jun 08 12:35:22 PlayStationMini huesync[15478]:     self.device.suspend(settings)
Jun 08 12:35:22 PlayStationMini huesync[15478]: TypeError: AllyLEDDevice.suspend() takes 1 positional argument but 2 were given
```

`AllyLEDDevice.suspend()`, `AyaNeoLEDDevice.suspend()`, `AllyLEDDevice.resume()` and `AyaNeoLEDDevice.resume()` were missing the `settings: dict = None` parameter required by the base class. The Ally and AyaNeo devices don't use suspend/resume settings (they just pass), so adding the parameter with a default of None is safe and non-breaking.