### PR TITLE
feat(legion-go-2): RGB support via hid-lenovo-go sysfs LED device

### DIFF
--- a/py_modules/config.py
+++ b/py_modules/config.py
@@ -52,6 +52,7 @@ except Exception as e:
     logger.error(f"Device information configuration error: {e}", exc_info=True)
 
 LED_PATH_LIST = [
+    "/sys/class/leds/go:rgb:joystick_rings",
     "/sys/class/leds/ayaneo:rgb:joystick_rings",
     "/sys/class/leds/ayn:rgb:joystick_rings",
     "/sys/class/leds/multicolor:chassis",

--- a/py_modules/devices/legion_go2.py
+++ b/py_modules/devices/legion_go2.py
@@ -1,0 +1,112 @@
+import os
+from typing import Optional
+
+from config import logger
+from utils import Color
+
+from .generic import GenericLEDDevice
+from .legion_power_led_mixin import LegionPowerLEDMixin
+
+# The kernel multicolor LED-class device exposed by the hid-lenovo-go driver
+# for the Legion Go 2 controller joystick rings.
+GO2_LED_PATH = "/sys/class/leds/go:rgb:joystick_rings"
+
+
+class LegionGo2LEDDevice(LegionPowerLEDMixin, GenericLEDDevice):
+    """
+    RGB control for the Lenovo Legion Go 2 via the in-kernel ``hid-lenovo-go``
+    driver, which exposes the joystick-ring RGB as the multicolor LED-class
+    device ``/sys/class/leds/go:rgb:joystick_rings``.
+
+    On kernels with this driver the raw vendor HID interface is claimed by the
+    driver (and hidden by InputPlumber), so the HID path used by
+    ``LegionGoTabletLEDDevice`` cannot open the device. This class drives the
+    sysfs LED instead. The go ring only lights when its ``enabled`` attribute is
+    ``true`` (the generic sysfs mixin never writes it), and it also needs
+    ``mode=custom`` / ``effect=monocolor`` for a static color, so
+    ``_set_color_by_sysfs`` is overridden to handle those.
+
+    Power LED control is inherited from ``LegionPowerLEDMixin`` using the same EC
+    field as the Legion Go tablet device (LEDP, offset 0x52 bit 5).
+
+    通过内核 hid-lenovo-go 驱动为 Lenovo Legion Go 2 提供 RGB 控制。
+    """
+
+    # Substring keywords for SysfsLEDMixin._detect_sysfs_led_path().
+    SYSFS_LED_PATHS = ["go:rgb:joystick_rings", "joystick_rings"]
+
+    # Power LED: same EC field as the Legion Go tablet (LEDP, offset 0x52 bit 5)
+    POWER_LED_OFFSET = 0x52
+    POWER_LED_BIT = 5
+
+    def __init__(self):
+        super().__init__()
+        # Cache of last-written static attributes so software animation effects
+        # (which call _set_solid_color per frame) don't re-write mode/effect/
+        # enabled/brightness every frame and flood the controller.
+        self._sysfs_cache: dict[str, str] = {}
+        self._max_brightness_val: Optional[int] = None
+
+    def _write_attr(self, attr: str, value: str) -> None:
+        if not self._sysfs_led_path:
+            return
+        path = os.path.join(self._sysfs_led_path, attr)
+        if os.path.exists(path):
+            with open(path, "w") as f:
+                f.write(value)
+
+    def _write_if_changed(self, attr: str, value: str) -> None:
+        if self._sysfs_cache.get(attr) == value:
+            return
+        self._write_attr(attr, value)
+        self._sysfs_cache[attr] = value
+
+    def _get_max_brightness(self) -> int:
+        if self._max_brightness_val is None:
+            self._max_brightness_val = 100
+            if self._sysfs_led_path:
+                mb_path = os.path.join(self._sysfs_led_path, "max_brightness")
+                try:
+                    if os.path.exists(mb_path):
+                        with open(mb_path) as f:
+                            self._max_brightness_val = int(f.read().strip())
+                except Exception:
+                    pass
+        return self._max_brightness_val
+
+    def _set_color_by_sysfs(
+        self, color: Color, brightness: Optional[int] = None
+    ) -> bool:
+        """
+        Set a solid color on the go ring. Overrides SysfsLEDMixin to also write
+        the go-specific ``mode``/``effect``/``enabled`` attributes and to clamp
+        brightness to the device's ``max_brightness`` (the ring is 0-100, not
+        the 0-255 the generic mixin assumes).
+        """
+        if not self._sysfs_led_path and not self._detect_sysfs_led_path():
+            logger.debug("No go:rgb sysfs LED path available")
+            return False
+
+        try:
+            is_off = color.R == 0 and color.G == 0 and color.B == 0
+            max_b = self._get_max_brightness()
+            bval = max_b if brightness is None else max(0, min(max_b, int(brightness)))
+
+            # Static attributes: write only when they change.
+            self._write_if_changed("mode", "custom")
+            self._write_if_changed("effect", "monocolor")
+            self._write_if_changed("brightness", str(bval))
+            # The ring is dark unless 'enabled' is true; a black color means off.
+            self._write_if_changed("enabled", "false" if is_off else "true")
+
+            # Color changes per frame for software effects, so always write it.
+            self._write_attr("multi_intensity", f"{color.R} {color.G} {color.B}")
+
+            logger.debug(
+                f"go:rgb set color=({color.R},{color.G},{color.B}) "
+                f"brightness={bval} off={is_off}"
+            )
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to set go:rgb color via sysfs: {e}")
+            return False

--- a/py_modules/huesync.py
+++ b/py_modules/huesync.py
@@ -15,6 +15,7 @@ from devices.ayaneo import AyaNeoLEDDevice
 from devices.generic import GenericLEDDevice
 from devices.gpd import GPDLEDDevice
 from devices.led_device import LEDDevice
+from devices.legion_go2 import LegionGo2LEDDevice
 from devices.legion_go_s import LegionGoSLEDDevice
 from devices.legion_go_tablet import LegionGoTabletLEDDevice
 from devices.msi import MSILEDDevice
@@ -130,6 +131,14 @@ class LedControl:
         if SYS_VENDOR == "LENOVO":
             # Check if it's Legion Go (tablet mode) or Legion Go S
             if PRODUCT_NAME in ["83E1", "83N0", "83N1"]:
+                # Legion Go 2 on kernels with the hid-lenovo-go driver expose the
+                # controller RGB as a sysfs LED-class device and hide the raw HID
+                # node, so the HID path fails there. Prefer the sysfs backend when
+                # that device is present; fall back to HID otherwise (and for the
+                # original Legion Go 83E1, which has no such node).
+                if os.path.exists("/sys/class/leds/go:rgb:joystick_rings"):
+                    logger.info("Using Legion Go 2 sysfs LED device (go:rgb:joystick_rings)")
+                    return LegionGo2LEDDevice()
                 logger.info("Using Legion Go (tablet mode) LED device (SYS_VENDOR + PRODUCT_NAME)")
                 return LegionGoTabletLEDDevice()
             else:


### PR DESCRIPTION
## Summary

Adds RGB support for the **Lenovo Legion Go 2** joystick rings.

On recent kernels the Legion Go 2 controller is bound by the in-kernel `hid-lenovo-go` driver, which claims the vendor HID interface (and InputPlumber hides the raw hidraw node) and instead exposes the ring RGB as the standard multicolor LED-class device `/sys/class/leds/go:rgb:joystick_rings`. Because of that:

- `LegionGoTabletLEDDevice`'s hidapi path can't open the device (`is_ready()` is false), so the rings never light; and
- `is_led_supported()` is `False` because `go:rgb:joystick_rings` isn't in `LED_PATH_LIST`,

so HueSync currently reports `device_type='generic', custom_rgb=False` and RGB controls don't work on the Go 2. (The original Legion Go, and Go 2 units on older kernels, still work via HID.)

## Changes

- **New `py_modules/devices/legion_go2.py`** — `LegionGo2LEDDevice(LegionPowerLEDMixin, GenericLEDDevice)`. Drives the sysfs LED and overrides `_set_color_by_sysfs` to also write the go-specific attributes:
  - `mode=custom`, `effect=monocolor` (static color),
  - `enabled=true`/`false` — **the ring is dark unless `enabled` is set** (the generic mixin never writes it; a black color maps to `enabled=false`),
  - brightness clamped to `max_brightness` (the ring is `0-100`, not the `0-255` the generic mixin assumes).

  Static attributes are cached so per-frame software effects don't flood the controller. Power LED reuses `LegionPowerLEDMixin` (same EC field as the tablet device).
- **`py_modules/huesync.py`** — for `83N0`/`83N1`, return `LegionGo2LEDDevice()` when `/sys/class/leds/go:rgb:joystick_rings` exists; otherwise fall back to the existing `LegionGoTabletLEDDevice` (HID). The `os.path.exists` guard keeps the original Legion Go (`83E1`) and older-kernel Go 2 units on the HID path.
- **`py_modules/config.py`** — add `go:rgb:joystick_rings` to `LED_PATH_LIST` so `is_led_supported()` reflects reality.

## Notes

- Python-only; no frontend rebuild. The standard mode + color UI is backend-driven; the Go 2 renders as a single 3-channel zone (`device_type='generic'`), which is correct.
- Uses software effects (Solid + Pulse/Rainbow/etc. via `GenericLEDDevice`). The hardware also supports `effect=breathe/chroma/rainbow`; exposing those natively could be a follow-up.

## Testing

On a Legion Go 2 (`83N0`): instantiating `LegionGo2LEDDevice` and setting colors correctly lights the joystick rings and updates the sysfs attributes (`enabled`, `mode=custom`, `effect=monocolor`, `multi_intensity`, brightness clamped to 100); a black color turns the rings off (`enabled=false`). The original Legion Go (`83E1`) is unaffected (no `go:rgb` node → HID path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
